### PR TITLE
Async fix

### DIFF
--- a/SoftLayer/SoapClient/AsynchronousAction.class.php
+++ b/SoftLayer/SoapClient/AsynchronousAction.class.php
@@ -150,7 +150,7 @@ class SoftLayer_SoapClient_AsynchronousAction
      */
     public function __construct($soapClient, $functionName, $request, $location, $action)
     {
-        preg_match('%^(http(?:s)?://)(.*?)(/.*?)$%', $location, $matches);
+        preg_match('%^(http(?:s)?)://(.*?)(/.*?)$%', $location, $matches);
 
         $this->_soapClient = $soapClient;
         $this->_functionName = $functionName;


### PR DESCRIPTION
Correction to regex in the AsynchronousAction class.
## Previous:

preg_match('%^(http(?:s)?://)(._?)(/._?)$%', $location, $matches);
## Updated to:

preg_match('%^(http(?:s)?)://(._?)(/._?)$%', $location, $matches);
