### PR TITLE
Adding a check for the init parameter

### DIFF
--- a/SoftLayer/SoapClient.class.php
+++ b/SoftLayer/SoapClient.class.php
@@ -265,7 +265,7 @@ class Softlayer_SoapClient extends SoapClient
             $soapClient->setAuthentication(self::API_USER, self::API_KEY);
         }
 
-        if ($id != null) {
+        if ($id !== null) {
             $soapClient->setInitParameter($id);
         }
 


### PR DESCRIPTION
We were not adding the init parameter if it was "0". This is needed for the "Additional services" SoftLayer_Product_Package
