### PR TITLE
The XmlrpcClient client throws fault on a php notice.

### DIFF
--- a/SoftLayer/XmlrpcClient.class.php
+++ b/SoftLayer/XmlrpcClient.class.php
@@ -151,7 +151,7 @@ class Softlayer_XmlrpcClient
             throw new Exception('There was an error querying the SoftLayer API: ' . $e->getMessage());
         }
 
-        if (xmlrpc_is_fault($result)) {
+        if (is_array($result) && xmlrpc_is_fault($result)) {
             throw new Exception('There was an error querying the SoftLayer API: ' . $result['faultString']);
         }
 


### PR DESCRIPTION
Fixed PHP notice when the result returned by an XML-RPC call is not an array.
