### PR TITLE
Fix caught exception class at `SoapClient::__call()`

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -198,8 +198,8 @@ class SoapClient extends \SoapClient
 
         try {
             $result = parent::__call($functionName, $arguments, null, $this->_headers, null);
-        } catch (SoapFault $e) {
-            throw new \Exception('There was an error querying the SoftLayer API: ' . $e->getMessage());
+        } catch (\SoapFault $e) {
+            throw new \Exception('There was an error querying the SoftLayer API: ' . $e->getMessage(), 0, $e);
         }
 
         if ($this->_asynchronous == true) {


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |yes   |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |
                      

Issue introduced at #10.